### PR TITLE
Fixes import snippet in installation page

### DIFF
--- a/docs-src/install.html
+++ b/docs-src/install.html
@@ -50,7 +50,7 @@
           You can do this from JavaScript or HTML:
 
           <h3>JavaScript / TypeScript</h3>
-          {% highlight "js" %}import from 'chessboard-element';{% endhighlight %}
+          {% highlight "js" %}import 'chessboard-element';{% endhighlight %}
 
           <h3>HTML</h3>
           {% highlight "html" %}<script type="module" src="/node_modules/chessboard-element/index.js"></script>{% endhighlight %}


### PR DESCRIPTION
I found this extraneous `from` in the installation examples. It doesn't work unless
we're defining a variable for the module.