### PR TITLE
add Shadow DOM css part "dragged-pieces"

### DIFF
--- a/src/lib/chessboard-element.ts
+++ b/src/lib/chessboard-element.ts
@@ -495,6 +495,7 @@ export class ChessBoardElement extends LitElement {
         )}
       </div>
       <div
+        part="dragged-pieces"
         id="dragged-pieces"
         style=${styleMap({
           width: `${this._squareSize}px`,


### PR DESCRIPTION
to set display none the dragged-pieces area

```css
chess-board::part(dragged-pieces) {
  display: none;
}
```

https://github.com/justinfagnani/chessboard-element/issues/8